### PR TITLE
docker: merge apt-get update and apt-get install

### DIFF
--- a/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/aarch64-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-aarch64-linux-gnu \

--- a/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-arm-linux-gnueabi \

--- a/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-gnueabihf/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-arm-linux-gnueabihf \

--- a/ci/docker/arm-unknown-linux-musleabi/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-arm-linux-gnueabi \

--- a/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/arm-unknown-linux-musleabihf/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-arm-linux-gnueabihf \

--- a/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-gnueabihf/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-arm-linux-gnueabihf \

--- a/ci/docker/armv7-unknown-linux-musleabihf/Dockerfile
+++ b/ci/docker/armv7-unknown-linux-musleabihf/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-arm-linux-gnueabihf \

--- a/ci/docker/i586-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i586-unknown-linux-gnu/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:14.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc-multilib

--- a/ci/docker/i686-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/i686-unknown-linux-gnu/Dockerfile
@@ -1,5 +1,5 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc-multilib

--- a/ci/docker/i686-unknown-linux-musl/Dockerfile
+++ b/ci/docker/i686-unknown-linux-musl/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc-multilib \
     musl-tools

--- a/ci/docker/mips-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mips-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-mips-linux-gnu \

--- a/ci/docker/mips-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mips-unknown-linux-musl/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     bzip2 \
     ca-certificates \
     curl \

--- a/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64-unknown-linux-gnuabi64/Dockerfile
@@ -1,13 +1,13 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-mips64-linux-gnuabi64 \
     libc6-dev \
     libc6-dev-mips64-cross \
-    qemu-user-static
-RUN apt-get install -y --no-install-recommends qemu-system-mips
+    qemu-user-static \
+    qemu-system-mips
 ENV CARGO_TARGET_MIPS64_UNKNOWN_LINUX_GNUABI64_LINKER=mips64-linux-gnuabi64-gcc \
     CC_mips64_unknown_linux_gnuabi64=mips64-linux-gnuabi64-gcc \
     QEMU_LD_PREFIX=/usr/mips64-linux-gnuabi64 \

--- a/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
+++ b/ci/docker/mips64el-unknown-linux-gnuabi64/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-mips64el-linux-gnuabi64 \

--- a/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-mipsel-linux-gnu \

--- a/ci/docker/mipsel-unknown-linux-musl/Dockerfile
+++ b/ci/docker/mipsel-unknown-linux-musl/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     bzip2 \
     ca-certificates \
     curl \

--- a/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:14.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-powerpc-linux-gnu \

--- a/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-powerpc64-linux-gnu \

--- a/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/powerpc64le-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-powerpc64le-linux-gnu \

--- a/ci/docker/s390x-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/s390x-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     gcc-s390x-linux-gnu \

--- a/ci/docker/thumbv6m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv6m-none-eabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     gcc \

--- a/ci/docker/thumbv7em-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     gcc \

--- a/ci/docker/thumbv7em-none-eabihf/Dockerfile
+++ b/ci/docker/thumbv7em-none-eabihf/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     gcc \

--- a/ci/docker/thumbv7m-none-eabi/Dockerfile
+++ b/ci/docker/thumbv7m-none-eabi/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
     gcc \

--- a/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-gnu/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:12.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     libc6-dev

--- a/ci/docker/x86_64-unknown-linux-musl/Dockerfile
+++ b/ci/docker/x86_64-unknown-linux-musl/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:16.04
-RUN apt-get update
-RUN apt-get install -y --no-install-recommends \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
     ca-certificates \
     gcc \
     libc6-dev \


### PR DESCRIPTION
to avoid 404 errors due to Docker image caching