### PR TITLE
cross-tag: keep cross up to date

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,7 +11,7 @@ main() {
         target=x86_64-apple-darwin
     fi
 
-    local tag="$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross | cut -d/ -f3 | tail -n1)"
+    local tag="$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross | cut -d/ -f3 | sort --version-sort | tail -n1)"
     echo cross version: $tag
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -7,16 +7,17 @@ main() {
     local target=
     if [ $TRAVIS_OS_NAME = linux ]; then
         target=x86_64-unknown-linux-gnu
+        sort=sort
     else
         target=x86_64-apple-darwin
-        brew install coreutils # for `sort --sort-version`
+        sort=gsort  # for `sort --sort-version`, from brew's coreutils.
     fi
 
     # This fetches latest stable release
     local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
                        | cut -d/ -f3 \
                        | grep -E '^v[0-9.]+$' \
-                       | sort --version-sort \
+                       | $sort --version-sort \
                        | tail -n1)
     echo cross version: $tag
     curl -LSfs https://japaric.github.io/trust/install.sh | \

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -9,6 +9,7 @@ main() {
         target=x86_64-unknown-linux-gnu
     else
         target=x86_64-apple-darwin
+        brew install coreutils # for `sort --sort-version`
     fi
 
     local tag="$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross | cut -d/ -f3 | sort --version-sort | tail -n1)"

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -12,7 +12,12 @@ main() {
         brew install coreutils # for `sort --sort-version`
     fi
 
-    local tag="$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross | cut -d/ -f3 | sort --version-sort | tail -n1)"
+    # This fetches latest stable release
+    local tag=$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross \
+                       | cut -d/ -f3 \
+                       | grep -E '^v[0-9.]+$' \
+                       | sort --version-sort \
+                       | tail -n1)
     echo cross version: $tag
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -11,13 +11,13 @@ main() {
         target=x86_64-apple-darwin
     fi
 
-    # TODO At some point you'll probably want to use a newer release of `cross`,
-    # simply change the argument to `--tag`.
+    local tag="$(git ls-remote --tags --refs --exit-code https://github.com/japaric/cross | cut -d/ -f3 | tail -n1)"
+    echo cross version: $tag
     curl -LSfs https://japaric.github.io/trust/install.sh | \
         sh -s -- \
            --force \
            --git japaric/cross \
-           --tag v0.1.4 \
+           --tag $tag \
            --target $target
 }
 


### PR DESCRIPTION
For https://github.com/japaric/trust/issues/56.

Note: the manpage for `git-ls-remote` does not seem to mention a sorting order.
Some code is needed to ensure we get the latest tag per semver's semantics.