### PR TITLE
Run `cargo clean` before building for target

### DIFF
--- a/ci/script.sh
+++ b/ci/script.sh
@@ -4,6 +4,7 @@ set -ex
 
 # TODO This is the "test phase", tweak it as you see fit
 main() {
+    cargo clean
     cross build --target $TARGET
     cross build --target $TARGET --release
 


### PR DESCRIPTION
Using cross with build scripts breaks sometimes, see https://github.com/japaric/cross/issues/39 . By cleaning first, we ensure we don't fail because of reusing build-scripts.

Fixes #60 .