### PR TITLE
Stop installing rust with rustup.rs twice

### DIFF
--- a/ci/install.sh
+++ b/ci/install.sh
@@ -1,9 +1,6 @@
 set -ex
 
 main() {
-    curl https://sh.rustup.rs -sSf | \
-        sh -s -- -y --default-toolchain $TRAVIS_RUST_VERSION
-
     local target=
     if [ $TRAVIS_OS_NAME = linux ]; then
         target=x86_64-unknown-linux-gnu


### PR DESCRIPTION
Since https://github.com/travis-ci/travis-ci/issues/7510 Travis now uses rustup.rs to install rust. This change will stop trust from installing rust a second time the exact same way that Travis does.