### PR TITLE
Use TLS for license texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,8 +179,8 @@ would
 Licensed under either of
 
 - Apache License, Version 2.0 ([LICENSE-APACHE](LICENSE-APACHE) or
-  http://www.apache.org/licenses/LICENSE-2.0)
-- MIT license ([LICENSE-MIT](LICENSE-MIT) or http://opensource.org/licenses/MIT)
+  https://www.apache.org/licenses/LICENSE-2.0)
+- MIT license ([LICENSE-MIT](LICENSE-MIT) or https://opensource.org/licenses/MIT)
 
 at your option.
 


### PR DESCRIPTION
The external link to the text of the Apache License 2.0 isn't HTTPS by default, which may be an issue to others, especially Tor users (who aren't using the Tor browser).