### PR TITLE
Remove sudo: required.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@
 dist: trusty
 language: rust
 services: docker
-sudo: required
 
 # TODO Rust builds on stable by default, this can be
 # overridden on a case by case basis down below.


### PR DESCRIPTION
This is a followup to #48.

It seems nothing is using sudo in trust, removing this line will default to `sudo: false`. This means, trust will run on [Travis container infrastructure](https://docs.travis-ci.com/user/reference/overview/#Virtualization-environments), which has faster boots and probably faster builds.

My testing showed that my repos run fine without sudo. I furthermore verified: 
- The docker service is brought up, even without `sudo: enabled`, so we are good there.
- `sudo apt-get` no longer works since there is no `sudo`. But apt packages can be installed using the [`apt` addon](https://docs.travis-ci.com/user/installing-dependencies/#Installing-Packages-with-the-APT-Addon). ([Example how this looks](https://github.com/googlecartographer/point_cloud_viewer/blob/736060a6323e5ddab2eb4dc09489a8162340c415/.travis.yml#L14)).