### PR TITLE
Fix windows build on travis

### DIFF
--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -21,7 +21,7 @@ main() {
     cross rustc --bin $CRATE_NAME --target $TARGET --release -- -C lto
 
     # TODO Update this to package the right artifacts
-    cp target/$TARGET/release/$CRATE_NAME $stage/
+    cp target/$TARGET/release/$CRATE_NAME $stage/ || cp target/$TARGET/release/$CRATE_NAME.exe $stage/
 
     cd $stage
     tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *

--- a/ci/before_deploy.sh
+++ b/ci/before_deploy.sh
@@ -18,10 +18,10 @@ main() {
     test -f Cargo.lock || cargo generate-lockfile
 
     # TODO Update this to build the artifacts that matter to you
-    cross rustc --bin hello --target $TARGET --release -- -C lto
+    cross rustc --bin $CRATE_NAME --target $TARGET --release -- -C lto
 
     # TODO Update this to package the right artifacts
-    cp target/$TARGET/release/hello $stage/
+    cp target/$TARGET/release/$CRATE_NAME $stage/
 
     cd $stage
     tar czf $src/$CRATE_NAME-$TRAVIS_TAG-$TARGET.tar.gz *


### PR DESCRIPTION
This patch makes building binaries for the `x86_64-pc-windows-gnu` target on travis possible