### PR TITLE
Fix PowerShell variable delimiter

### DIFF
--- a/ci/before_deploy.ps1
+++ b/ci/before_deploy.ps1
@@ -8,10 +8,10 @@ Set-Location $ENV:Temp
 New-Item -Type Directory -Name $STAGE
 Set-Location $STAGE
 
-$ZIP = "$SRC_DIR\$($Env:CRATE_NAME)-$($Env:APPVEYOR_REPO_TAG_NAME)-$($Env:TARGET).zip"
+$ZIP = "$SRC_DIR\${Env:CRATE_NAME}-${Env:APPVEYOR_REPO_TAG_NAME}-${Env:TARGET}.zip"
 
 # TODO Update this to package the right artifacts
-Copy-Item "$SRC_DIR\target\$($Env:TARGET)\release\hello.exe" '.\'
+Copy-Item "$SRC_DIR\target\${Env:TARGET}\release\hello.exe" '.\'
 
 7z a "$ZIP" *
 


### PR DESCRIPTION
PowerShell's rules for substitution are complex but `$()` is for execution
and apparently that's not what happens in `before_deploy.ps1`. It looks like `$($foo.Bar)` to access `$foo`'s `Bar` property would have needed `$()`, though.