### PR TITLE
Add email address line for notifications

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -87,6 +87,8 @@ branches:
 
 notifications:
   - provider: Email
+    to:
+      - some@email.com
     on_build_success: false
 
 # Building is done in the test phase, so we disable Appveyor's build phase.


### PR DESCRIPTION
To resolve the error:
 Error sending Email notification: Object reference not set to an instance of an object.

I left the Appveyor default, as shown here:
https://www.appveyor.com/docs/notifications/#triggering-notifications