### PR TITLE
Add 32-bit Windows target to .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,7 @@ matrix:
     - env: TARGET=x86_64-unknown-netbsd DISABLE_TESTS=1
 
     # Windows
+    - env: TARGET=i686-pc-windows-gnu
     - env: TARGET=x86_64-pc-windows-gnu
 
     # Bare metal


### PR DESCRIPTION
It seems to work fine in my project. Many people still use 32-bit Windows, so I think it makes sense to add it.