### PR TITLE
Remove rustc dependency when installing from a release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -96,11 +96,6 @@ if [ -z $tag ]; then
     need rev
 fi
 
-if [ -z $target ]; then
-    need grep
-    need rustc
-fi
-
 if [ -z $git ]; then
     err 'must specify a git repository using `--git`. Example: `install.sh --git japaric/cross`'
 fi
@@ -124,7 +119,20 @@ else
 fi
 
 if [ -z $target ]; then
-    target=$(rustc -Vv | grep host | cut -d' ' -f2)
+    kernel="$(uname -s)"
+    case $kernel in
+        "Darwin")
+            platform="apple-darwin"
+            ;;
+        "Linux")
+            platform="unknown-linux-gnu"
+            ;;
+        *)
+            err "unknown kernel $kernel"
+            ;;
+    esac
+
+    target="$(uname -m)-$platform"
 fi
 
 say_err "Target: $target"


### PR DESCRIPTION
Fixes #120

Doesn't fix @casey's [comment](https://github.com/japaric/trust/issues/120#issuecomment-524506448) since that's a slightly more complicated change.