### PR TITLE
docs: update Travis CI url

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 
 - Your crate must be hosted on GitHub (free).
 
-- A [Travis CI](https://travis-ci.org/) account (free).
+- A [Travis CI](https://travis-ci.com/) account (free).
 
 - An [AppVeyor](https://www.appveyor.com/) account (free).
 


### PR DESCRIPTION
The recommended URL is now https://travis-ci.com, not https://travis-ci.org