### PR TITLE
Fix latest Git tag detection in install script on GitHub Pages

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -117,7 +117,8 @@ say_err "Crate: $crate"
 url="$url/releases"
 
 if [ -z $tag ]; then
-    tag=$(curl -s "$url/latest" | cut -d'"' -f2 | rev | cut -d'/' -f1 | rev)
+    apiUrl="https://api.github.com/repos/$git/releases/latest"
+    tag=$(curl -sL "$apiUrl" | grep '"tag_name":' | cut -d'"' -f4)
     say_err "Tag: latest ($tag)"
 else
     say_err "Tag: $tag"


### PR DESCRIPTION
Fixes #130 
Supersedes #124 

## Synopsis

Explained here: https://github.com/japaric/trust/issues/130#issuecomment-1315085924


## Solution

Parse latest Git tag name from JSON returned by `https://api.github.com/repos/$git/releases/latest`.